### PR TITLE
Add webhooks to Fury Gates, Nightmare Isle, Rashid, Yasir.

### DIFF
--- a/data/scripts/globalevents/spawn/rashid.lua
+++ b/data/scripts/globalevents/spawn/rashid.lua
@@ -8,6 +8,10 @@ local positionByDay = {
 	[7] = {position = Position(33166, 31810, 6), city = "Edron"}  -- Saturday
 }
 
+local function rashidwebhook(message) -- New local function that runs on delay to send webhook message.
+	Webhook.send("[Rashid] ", message, WEBHOOK_COLOR_ONLINE) --Sends webhook message
+end
+
 local rashid = GlobalEvent("rashid")
 function rashid.onStartup()
 
@@ -19,6 +23,8 @@ function rashid.onStartup()
 		rashid:setMasterPos(config.position)
 		rashid:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
 		Spdlog.info(string.format("Rashid arrived at %s", config.city))
+		local message = string.format("Rashid arrived at %s today.", config.city) -- Declaring the message to send to webhook.
+		addEvent(rashidwebhook, 60000, message) -- Event with 1 minute delay to send webhook message after server starts.
 	else
 		Spdlog.warn(string.format("[rashid.onStartup] - Cannot create Rashid. Day: %s",
 			os.date("%A")))
@@ -38,10 +44,12 @@ function rashidSpawnOnTime.onTime(interval)
 
 	if rashidTarget then
 		Spdlog.info("Rashid is traveling to " .. os.date("%A") .. "s location.")
+		local message = ("Rashid is traveling to " .. os.date("%A") .. "s location.") -- Declaring the message to send to webhook.
 		rashidTarget:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
 		rashidTarget:teleportTo(positionByDay[today])
 		rashidTarget:setMasterPos(positionByDay[today])
 		rashidTarget:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
+		addEvent(rashidwebhook, 60000, message) -- Event with 1 minute delay to send webhook message after server starts.
 	end
 
 	return true

--- a/data/scripts/globalevents/spawn/rashid.lua
+++ b/data/scripts/globalevents/spawn/rashid.lua
@@ -44,7 +44,7 @@ function rashidSpawnOnTime.onTime(interval)
 
 	if rashidTarget then
 		Spdlog.info("Rashid is traveling to " .. os.date("%A") .. "s location.")
-		local message = ("Rashid is traveling to " .. os.date("%A") .. "s location.") -- Declaring the message to send to webhook.
+		local message = ("Rashid is traveling to " .. os.date("%A") .. "s location.")
 		rashidTarget:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
 		rashidTarget:teleportTo(positionByDay[today])
 		rashidTarget:setMasterPos(positionByDay[today])

--- a/data/scripts/globalevents/worldchanges/fury_gates.lua
+++ b/data/scripts/globalevents/worldchanges/fury_gates.lua
@@ -128,7 +128,7 @@ function furygates.onStartup(interval)
 
 	Spdlog.info(string.format("Fury Gate will be active in %s today",
 		gates[gateId].city))
-	local message = (string.format("Fury Gate will be active in %s today", 
+	local message = (string.format("Fury Gate will be active in %s today",
 		gates[gateId].city))	-- Declaring the message to send to webhook.
 	addEvent(Furywebhook, 60000, message)	-- Event with 1 minute delay to send webhook message after server starts.
 

--- a/data/scripts/globalevents/worldchanges/fury_gates.lua
+++ b/data/scripts/globalevents/worldchanges/fury_gates.lua
@@ -100,6 +100,9 @@ local gates = {
 	}
 }
 
+local function Furywebhook(message)	-- New local function that runs on delay to send webhook message.
+	Webhook.send("[Fury Gates] ", message, WEBHOOK_COLOR_ONLINE)	--Sends webhook message
+end
 
 -- FURY GATES MAP LOAD
 
@@ -125,6 +128,9 @@ function furygates.onStartup(interval)
 
 	Spdlog.info(string.format("Fury Gate will be active in %s today",
 		gates[gateId].city))
+	local message = (string.format("Fury Gate will be active in %s today", 
+		gates[gateId].city))	-- Declaring the message to send to webhook.
+	addEvent(Furywebhook, 60000, message)	-- Event with 1 minute delay to send webhook message after server starts.
 
 	return true
 end

--- a/data/scripts/globalevents/worldchanges/nightmare_isle.lua
+++ b/data/scripts/globalevents/worldchanges/nightmare_isle.lua
@@ -16,12 +16,19 @@ local config = {
 	}
 }
 
+local function Nightmarewebhook(message)	-- New local function that runs on delay to send webhook message.
+	Webhook.send("[Nightmare Isle] ", message, WEBHOOK_COLOR_ONLINE)	--Sends webhook message
+end
+
 local NightmareIsle = GlobalEvent("NightmareIsle")
 function NightmareIsle.onStartup(interval)
 	local select = config[math.random(#config)]
 	Game.loadMap('data/world/nightmareisle/' .. select.mapName .. '.otbm')
 	Spdlog.info(string.format("[WorldChanges] Nightmare Isle will be active %s today",
 	select.displayName))
+	local message = string.format("Nightmare Isle will be active %s today",
+	select.displayName)	-- Declaring the message to send to webhook.
+	addEvent(Nightmarewebhook, 60000, message) -- Event with 1 minute delay to send webhook message after server starts.
 
 	setGlobalStorageValue(GlobalStorage.NightmareIsle, 1)
 

--- a/data/scripts/globalevents/worldchanges/yasir.lua
+++ b/data/scripts/globalevents/worldchanges/yasir.lua
@@ -45,6 +45,10 @@ local config = {
 	}
 }
 
+local function yasirwebhook(message) -- New local function that runs on delay to send webhook message.
+	Webhook.send("[Yasir] ", message, WEBHOOK_COLOR_ONLINE) --Sends webhook message
+end
+
 local yasirEnabled = true
 local yasirChance = 33
 
@@ -61,6 +65,7 @@ function yasir.onStartup()
 		if math.random(100) <= yasirChance then
 			local randTown = config[math.random(#config)]
 			Spdlog.info(string.format("[WorldChanges] Yasir: %s", randTown.mapName))
+			local message = string.format("Yasir is in %s today.", randTown.mapName) -- Declaring the message to send to webhook.
 			iterateArea(
 			function(position)
 				local tile = Tile(position)
@@ -94,9 +99,12 @@ function yasir.onStartup()
 
 			Game.loadMap('data/world/yasir/' .. randTown.mapName .. '.otbm')
 			addEvent(spawnYasir, 5000, randTown.yasirPosition)
+			addEvent(yasirwebhook, 60000, message) -- Event with 1 minute delay to send webhook message after server starts.
 			setGlobalStorageValue(GlobalStorage.Yasir, 1)
 		else
 			Spdlog.info("Yasir: not this time")
+			local message = "Yasir: not spawned today" -- Declaring the message to send to webhook.
+			addEvent(yasirwebhook, 60000, message) -- Event with 1 minute delay to send webhook message after server starts.
 			setGlobalStorageValue(GlobalStorage.Yasir, 0)
 		end
 	end


### PR DESCRIPTION
# Description

Adds a webhook notification for Fury Gates, Nightmare Isle, Rashid, and Yasir that posts their current status to discord.

## Behaviour
### **Actual**

New feature.

### **Expected**

New feature.

## Fixes

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  Input code, start server, wait 1 minute, webhook messages will appear in your webhooked discord channel.

**Test Configuration**:

  - Server Version: Latest
  - Client: N/A
  - Operating System: N/A

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [X] I have commented my code, particularly in hard-to-understand areas
  - [  ]  I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [X] I have added tests that prove my fix is effective or that my feature works
  
![image](https://user-images.githubusercontent.com/85965963/124390502-8eeab280-dcb1-11eb-979f-2423d8912636.png)