### PR TITLE
Storage overlap between Threatened Dreams and Killing in the name of

### DIFF
--- a/data/lib/core/storages.lua
+++ b/data/lib/core/storages.lua
@@ -410,6 +410,7 @@ Storage = {
 		-- Reserved storage from 50270 - 50349
 		Start = 50270,
 		TroubledMission01 = 50271,
+		PoacherChest = 50306,
 		TroubledMission02 = 50272,
 		TroubledMission03 = 50273,
 		FairyMission01 = 50274,

--- a/data/lib/core/storages.lua
+++ b/data/lib/core/storages.lua
@@ -410,7 +410,6 @@ Storage = {
 		-- Reserved storage from 50270 - 50349
 		Start = 50270,
 		TroubledMission01 = 50271,
-		PoacherChest = 50306,
 		TroubledMission02 = 50272,
 		TroubledMission03 = 50273,
 		FairyMission01 = 50274,
@@ -431,7 +430,8 @@ Storage = {
 		TatteredSwanFeathers02 = 50302,
 		TatteredSwanFeathers03 = 50303,
 		TatteredSwanFeathers04 = 50304,
-		TatteredSwanFeathers05 = 50305
+		TatteredSwanFeathers05 = 50305,
+		PoacherChest = 50306
 	},
 	FirstDragon = {
 		-- Reserved storage from 50350 - 50379

--- a/data/scripts/actions/quests/threatened_dreams/poacher_chest.lua
+++ b/data/scripts/actions/quests/threatened_dreams/poacher_chest.lua
@@ -1,12 +1,12 @@
 local chests = {
-	[34123] = {itemid = 28596, count = 1}
+	[50306] = {itemid = 28596, count = 1}
 }
 
 local poacherChest = Action()
 function poacherChest.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	if (player:getStorageValue(Storage.ThreatenedDreams.TroubledMission01) == 1) then
 		if chests[item.uid] then
-			if player:getStorageValue(34123) == 1 then
+			if player:getStorageValue(Storage.ThreatenedDreams.PoacherChest) == 1 then
 				player:sendTextMessage(MESSAGE_EVENT_ADVANCE, 'It\'s empty.')
 				return true
 			end
@@ -19,7 +19,7 @@ function poacherChest.onUse(player, item, fromPosition, target, toPosition, isHo
 			end
 
 			player:addItem(chest.itemid, chest.count)
-			player:setStorageValue(34123, 1)
+			player:setStorageValue(Storage.ThreatenedDreams.PoacherChest, 1)
 			player:setStorageValue(Storage.ThreatenedDreams.TroubledMission01, 2)
 		end
 	else
@@ -28,5 +28,5 @@ function poacherChest.onUse(player, item, fromPosition, target, toPosition, isHo
 	return true
 end
 
-poacherChest:uid(34123)
+poacherChest:uid(50306)
 poacherChest:register()

--- a/data/scripts/actions/quests/threatened_dreams/poacher_chest.lua
+++ b/data/scripts/actions/quests/threatened_dreams/poacher_chest.lua
@@ -1,5 +1,5 @@
 local chests = {
-	[50306] = {itemid = 28596, count = 1}
+	[14036] = {itemid = 28596, count = 1}
 }
 
 local poacherChest = Action()
@@ -28,5 +28,5 @@ function poacherChest.onUse(player, item, fromPosition, target, toPosition, isHo
 	return true
 end
 
-poacherChest:uid(50306)
+poacherChest:uid(14036)
 poacherChest:register()

--- a/data/startup/tables/chest.lua
+++ b/data/startup/tables/chest.lua
@@ -1001,7 +1001,7 @@ ChestUnique = {
 	},
 	-- Others uniques
 	-- Threatened Dreams Quest
-	[34123] = {
+	[50306] = {
 		itemId = 13903,
 		itemPos = {x = 32787, y = 31975, z = 11}
 	}

--- a/data/startup/tables/chest.lua
+++ b/data/startup/tables/chest.lua
@@ -1001,7 +1001,7 @@ ChestUnique = {
 	},
 	-- Others uniques
 	-- Threatened Dreams Quest
-	[50306] = {
+	[14036] = {
 		itemId = 13903,
 		itemPos = {x = 32787, y = 31975, z = 11}
 	}


### PR DESCRIPTION
Add new storage for poacher chest so it can be used as a Unique ID for chest.


# Description

Poacher chest for Threatened Dreams gives a storage ID assigned to the Killing In The Name Of Hellhound boss (34123)

## Behaviour
### **Actual**

Doing the Threatened Dreams quest allows you to kill the Hellhound boss because it gives the boss's storageID.

### **Expected**

Not be able to kill hellhound boss by doing Threatened Dream Quest.

## Fixes

N/A

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Changed values, was able to do quest with new values, no storage overlap.

**Test Configuration**:

  - Server Version: Latest
  - Client: N/A
  - Operating System: N/A

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
